### PR TITLE
Preallocate `attention_mask`, and do not call `_prepare_decoder_attention_mask` for batch size = 1

### DIFF
--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -173,12 +173,14 @@ for batch_size in tqdm(BATCH_SIZES):
         for max_new_tokens in tqdm(NEW_TOKENS):
             cache_length = 1 * (prompt_length + max_new_tokens)
 
+            inp = {
+                "input_ids": torch.randint(low=1, high=10, size=(batch_size, prompt_length)).to("cuda"),
+                "attention_mask": torch.ones(batch_size, prompt_length, dtype=torch.int32).to("cuda")
+            }
+
             if batch_size > 1:
                 inp["input_ids"][0, :10] = tokenizer.pad_token_id
                 inp["attention_mask"][0, :10] = 0
-
-            inp = tokenizer(["This is ", "He was my father but also my"], return_tensors="pt", padding=True).to("cuda")
-            prompt_length = inp["input_ids"].shape[1]
 
             h = hashlib.new('sha256')
             h.update(str(inp).encode())

--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -173,10 +173,12 @@ for batch_size in tqdm(BATCH_SIZES):
         for max_new_tokens in tqdm(NEW_TOKENS):
             cache_length = 1 * (prompt_length + max_new_tokens)
 
-            inp = {
-                "input_ids": torch.randint(low=1, high=10, size=(batch_size, prompt_length)).to("cuda"),
-                "attention_mask": torch.ones(batch_size, prompt_length, dtype=torch.int32).to("cuda")
-            }
+            if batch_size > 1:
+                inp["input_ids"][0, :10] = tokenizer.pad_token_id
+                inp["attention_mask"][0, :10] = 0
+
+            inp = tokenizer(["This is ", "He was my father but also my"], return_tensors="pt", padding=True).to("cuda")
+            prompt_length = inp["input_ids"].shape[1]
 
             h = hashlib.new('sha256')
             h.update(str(inp).encode())

--- a/src/trfs_fast/generation.py
+++ b/src/trfs_fast/generation.py
@@ -113,8 +113,12 @@ class GenerationPrefill:
         if streamer is not None:
             streamer.put(input_ids.cpu())
 
+        batch_size, context_length = input_ids.shape
+        cache_length = cache_length if cache_length is not None else max_new_tokens
+
         model_kwargs["valid_past_index"] = 0
-        model_kwargs["past_key_values"] = self.get_empty_kv_cache(batch_size=input_ids.shape[0], cache_length=cache_length if cache_length is not None else max_new_tokens, device=input_ids.device, dtype=self.dtype)
+        model_kwargs["past_key_values"] = self.get_empty_kv_cache(batch_size=batch_size, cache_length=cache_length, device=input_ids.device, dtype=self.dtype)
+        model_kwargs["attention_mask"] = self.get_preallocated_attention_mask(attention_mask=model_kwargs["attention_mask"], batch_size=batch_size, cache_length=cache_length, device=input_ids.device, context_length=context_length)
 
         # 11. run greedy search
         return self.greedy_search_minimal(
@@ -205,7 +209,7 @@ class GenerationPrefill:
             if streamer is not None:
                 streamer.put(next_tokens.cpu())
             model_kwargs = self.__update_model_kwargs_for_generation(
-                outputs, model_kwargs
+                outputs, model_kwargs, model_inputs
             )
 
             # if eos_token was found in one sentence, set sentence to finished
@@ -231,21 +235,31 @@ class GenerationPrefill:
         self,
         outputs: ModelOutput,
         model_kwargs: Dict[str, Any],
+        model_inputs: Dict[str, Any]
     ) -> Dict[str, Any]:
         model_kwargs["valid_past_index"] += outputs.logits.shape[1]
         
         if getattr(outputs, "state", None) is not None:
             model_kwargs["state"] = outputs.state
 
-        # update token_type_ids with last value
-        if "token_type_ids" in model_kwargs:
-            token_type_ids = model_kwargs["token_type_ids"]
-            model_kwargs["token_type_ids"] = torch.cat([token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1)
         # update attention mask
+        """
         if "attention_mask" in model_kwargs:
             attention_mask = model_kwargs["attention_mask"]
             model_kwargs["attention_mask"] = torch.cat(
                 [attention_mask, attention_mask.new_ones((attention_mask.shape[0], 1))], dim=-1
             )
+        """
+        position_ids = model_inputs.get("position_ids", None)
+        if position_ids.shape[1] > 1:
+            model_kwargs["position_ids"] = position_ids[:, -2:-1] + 1
+        else:
+            model_kwargs["position_ids"] = position_ids + 1
+
+        # NOTE: token_type_ids is not used by llama so we don't care about this one for now
+        # update token_type_ids with last value
+        if "token_type_ids" in model_kwargs:
+            token_type_ids = model_kwargs["token_type_ids"]
+            model_kwargs["token_type_ids"] = torch.cat([token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1)
         
         return model_kwargs

--- a/src/trfs_fast/generation.py
+++ b/src/trfs_fast/generation.py
@@ -250,12 +250,12 @@ class GenerationPrefill:
                 [attention_mask, attention_mask.new_ones((attention_mask.shape[0], 1))], dim=-1
             )
         """
-        position_ids = model_inputs.get("position_ids", None)
+        position_ids = model_inputs["position_ids"]
         if position_ids.shape[1] > 1:
-            model_kwargs["position_ids"] = position_ids[:, -2:-1] + 1
+            model_kwargs["position_ids"] = position_ids[:, -1:] + 1
         else:
             model_kwargs["position_ids"] = position_ids + 1
-
+        
         # NOTE: token_type_ids is not used by llama so we don't care about this one for now
         # update token_type_ids with last value
         if "token_type_ids" in model_kwargs:


### PR DESCRIPTION
As we use pytorch SDPA, there is no need for an attention mask for the batch_size = 1 (which is automatically handled by `is_causal=True/False`).

We also preallocate an `attention_mask` buffer, which **very marginally** (0.1% - 0.2%) helps with latency in the batch size > 1 case, see below. Maybe we can do better, still have to profile. Must importantly, the model I/O has static shapes now.

Numbers below on the A10G from the README.

I did not test torch.compile.

|version     |batch_size|prompt_length|new_tokens|cache_length|dtype|tok_per_s|max_mem_mb|hash    |
|------------|----------|-------------|----------|------------|-----|---------|----------|--------|
|transformers|1         |1000         |200       |1200        |fp16 |23.096   |14776.09  |0d6aa042|
|main        |1         |1000         |200       |1200        |fp16 |27.329   |14249.72  |0d6aa042|
|this_pr     |1         |1000         |200       |1200        |fp16 |27.402   |14247.73  |0d6aa042|

|version|batch_size|prompt_length|new_tokens|cache_length|dtype|tok_per_s|max_mem_mb|hash    |
|-------|----------|-------------|----------|------------|-----|---------|----------|--------|
|main   |1         |1000         |1000      |2000        |fp16 |27.653   |14693.21  |53d1a03e|
|this_pr|1         |1000         |1000      |2000        |fp16 |27.780   |14691.22  |53d1a03e|

|version|batch_size|prompt_length|new_tokens|cache_length|dtype|tok_per_s|max_mem_mb|hash    |
|-------|----------|-------------|----------|------------|-----|---------|----------|--------|
|transformers|4         |1000         |200       |1200        |fp16 |17.336   |18569.85  |1f79bceb|
|main   |4         |1000         |200       |1200        |fp16 |20.369   |16828.93  |241512dc|
|this_pr|4         |1000         |200       |1200        |fp16 |20.404   |16828.97  |1f79bceb|

|version|batch_size|prompt_length|new_tokens|cache_length|dtype|tok_per_s|max_mem_mb|hash    |
|-------|----------|-------------|----------|------------|-----|---------|----------|--------|
|transformers|OOM
|main   |8         |1000         |200       |1200        |fp16 |15.444   |20069.19  |a0b67cda|
|this_pr|8         |1000         |200       |1200        |fp16 |15.455   |20069.27  |16011ee6|

|version|batch_size|prompt_length|new_tokens|cache_length|dtype|tok_per_s|max_mem_mb|hash    |
|-------|----------|-------------|----------|------------|-----|---------|----------|--------|
|transformers|4         |1000         |400       |1400        |fp16 |17.219   |19403.21  |219025a2|
|main   |4         |1000         |400       |1400        |fp16 |21.231   |17231.59  |514b4692|
|this_pr|4         |1000         |400       |1400        |fp16 |21.270   |17231.64  |219025a2|

Note that the different hash between `main` and `this_pr` is expected, in `main`'s `run_llama.py` we were not simulating left padding.