### PR TITLE
Llama compile

### DIFF
--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -18,6 +18,7 @@ from trfs_fast.utils import recurse_getattr, recurse_hasattr, recurse_setattr, r
 BATCH_SIZES = [1]
 PROMPT_LENGTHS = [1000]
 NEW_TOKENS = [200]
+NUM_RUNS = 50
 
 parser = argparse.ArgumentParser()
 
@@ -167,7 +168,8 @@ if args.preallocate:
 
                 weight = torch.nn.Parameter(torch.cat([
                     copy.deepcopy(recurse_getattr(original_model, base_root_query)),
-                    copy.deepcopy(recurse_getattr(original_model, base_root_key)), copy.deepcopy(recurse_getattr(original_model, base_root_value))
+                    copy.deepcopy(recurse_getattr(original_model, base_root_key)),
+                    copy.deepcopy(recurse_getattr(original_model, base_root_value))
                 ], dim=0))
 
                 recurse_setattr(model, name, weight)
@@ -208,7 +210,7 @@ for batch_size in tqdm(BATCH_SIZES):
             generate_method = model.generate if not args.preallocate else model.generate_minimal
             time_per_generation, max_memory, sha_hash = timing_cuda(
                 tokenizer=tokenizer,
-                num_runs=3,
+                num_runs=NUM_RUNS,
                 inputs=inp,
                 device=device,
                 max_new_tokens=max_new_tokens,

--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -1,21 +1,22 @@
-from tqdm import tqdm
-
-import torch
-
+import argparse
+import copy
+import hashlib
+import os
 from typing import Tuple, Dict
 
-import hashlib
+from tqdm import tqdm
+import torch
+from torch.profiler import ProfilerActivity, profile, record_function, tensorboard_trace_handler
+
 import transformers
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from trfs_fast.llama import LlamaForCausalLM
-from torch.profiler import ProfilerActivity, profile, record_function, tensorboard_trace_handler
-
 from trfs_fast.utils import recurse_getattr, recurse_hasattr, recurse_setattr, recurse_delattr
 
-import argparse
-import copy
 
+# Debugging torch.compile
+os.environ["TORCHDYNAMO_REPORT_GUARD_FAILURES"] = "1"
 
 parser = argparse.ArgumentParser()
 
@@ -163,7 +164,7 @@ else:
 
 
 if args.compile:
-    model.forward = torch.compile(model.forward, mode="reduce-overhead", dynamic=True)
+    model.forward = torch.compile(model.forward, mode="reduce-overhead")
 
 if model.config.model_type != "llama":
     raise ValueError("This script currently only supports LLAMA")

--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -163,7 +163,7 @@ else:
 
 
 if args.compile:
-    model.forward = torch.compile(model.forward)
+    model.forward = torch.compile(model.forward, mode="reduce-overhead", dynamic=True)
 
 if model.config.model_type != "llama":
     raise ValueError("This script currently only supports LLAMA")

--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -40,8 +40,10 @@ parser.add_argument(
 )
 parser.add_argument(
     "--compile",
-    action='store_true',
-    help="Whether to compile the model forward pass with torch.compile",
+    type=str,
+    choices=["no", "static", "dynamic"],
+    default="no",
+    help="If (and how) to compile the model forward pass with torch.compile",
 )
 
 
@@ -163,8 +165,9 @@ else:
         model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype=dtype)
 
 
-if args.compile:
-    model.forward = torch.compile(model.forward, mode="reduce-overhead")
+if args.compile != "no":
+    dynamic = args.compile == "dynamic"
+    model.forward = torch.compile(model.forward, mode="reduce-overhead", dynamic=dynamic)
 
 if model.config.model_type != "llama":
     raise ValueError("This script currently only supports LLAMA")


### PR DESCRIPTION
Exploring llama + `torch.compile`. Writing findings as I go along. Using PT 2.1 nightly

### Key Llama changes
1. As identified by Felix, squeezing multiple dims in a single call crashes compile. Made into one squeezed dim per call 
   - uncompiled: no noticeable changes.
   - compilation with `dynamic=True`: it now works, very minor speedups, a few extra MBs requested; 
   - compilation with `dynamic=False`: works but takes ~30mins, significant slowdowns.
2. `sin` and `cos`, the output of `LlamaRotaryEmbedding.forward`, has dynamic shapes. Made it static. 
   - (no performance changes)
3. `valid_past_index` int -> tensor (was the source of recompilations). Changes some llama logic related to this variable to avoid dynamic control flow.
   - uncompiled: slightly slower 👎 
   - compilation with `dynamic=True`: crashes 🙅 
   - compilation with `dynamic=False`: now compiles in ~1 minute. Faster if we repeat the experiment for a large number of runs (20+ runs)