### PR TITLE
Fix latency regression

### DIFF
--- a/src/trfs_fast/generation.py
+++ b/src/trfs_fast/generation.py
@@ -116,7 +116,7 @@ class GenerationPrefill:
         batch_size, context_length = input_ids.shape
         cache_length = cache_length if cache_length is not None else max_new_tokens
 
-        model_kwargs["valid_past_index"] = torch.tensor(0).to(input_ids.device)
+        model_kwargs["valid_past_index"] = torch.tensor(0, dtype=torch.int64)
         model_kwargs["past_key_values"] = self.get_empty_kv_cache(batch_size=batch_size, cache_length=cache_length, device=input_ids.device, dtype=self.dtype)
         model_kwargs["attention_mask"] = self.get_preallocated_attention_mask(attention_mask=model_kwargs["attention_mask"], batch_size=batch_size, cache_length=cache_length, device=input_ids.device, context_length=context_length)
 

--- a/src/trfs_fast/llama.py
+++ b/src/trfs_fast/llama.py
@@ -193,7 +193,7 @@ class LlamaAttention(nn.Module):
         position_ids: Optional[torch.LongTensor] = None,
         past_key_value: Optional[Tuple[torch.Tensor]] = None,
         output_attentions: bool = False,
-        valid_past_index: torch.Tensor = torch.Tensor(0),
+        valid_past_index: torch.Tensor = torch.tensor(0, dtype=torch.int64),
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
         if output_attentions is True:
             raise ValueError("output_attentions=True can not be supported with BetterTransformer.")
@@ -264,7 +264,7 @@ class LlamaDecoderLayer(nn.Module):
         position_ids: Optional[torch.LongTensor] = None,
         past_key_value: Optional[Tuple[torch.Tensor]] = None,
         output_attentions: Optional[bool] = False,
-        valid_past_index: torch.Tensor = torch.Tensor(0),
+        valid_past_index: torch.Tensor = torch.tensor(0, dtype=torch.int64),
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
         """
         Args:
@@ -484,7 +484,7 @@ class LlamaModel(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        valid_past_index: torch.Tensor = torch.Tensor(0),
+        valid_past_index: torch.Tensor = torch.tensor(0, dtype=torch.int64),
     ) -> Union[Tuple, BaseModelOutputWithPast]:
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -653,7 +653,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationPrefill):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-        valid_past_index: torch.Tensor = torch.Tensor(0),
+        valid_past_index: torch.Tensor = torch.tensor(0, dtype=torch.int64),
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
         Args:
@@ -731,7 +731,7 @@ class LlamaForCausalLM(LlamaPreTrainedModel, GenerationPrefill):
     def prepare_inputs_for_generation(
         self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
-        valid_past_index = kwargs.get("valid_past_index", torch.Tensor(0))
+        valid_past_index = kwargs.get("valid_past_index", torch.tensor(0, dtype=torch.int64))
 
         if valid_past_index > 0:
             input_ids = input_ids[:, -1:]


### PR DESCRIPTION
Fix regression introduced by https://github.com/fxmarty/accelerated-pytorch-transformers-generation/pull/6, that places `valid_past_index` on cuda device although aten::slice operations are cpu ops

Goes from:
```
batch_size,compile,prompt_length,new_tokens,cache_length,dtype,tok_per_s,max_mem_mb,hash
1,no,1000,200,1200,fp16,24.197,14248.19,0d6aa042
```
to
```
batch_size,compile,prompt_length,new_tokens,cache_length,dtype,tok_per_s,max_mem_mb,hash
1,no,1000,200,1200,fp16,27.166,14248.19,0d6aa042
```