### PR TITLE
rotate_half without cat

### DIFF
--- a/src/trfs_fast/llama.py
+++ b/src/trfs_fast/llama.py
@@ -126,9 +126,10 @@ class LlamaRotaryEmbedding(torch.nn.Module):
 
 def rotate_half(x):
     """Rotates half the hidden dims of the input."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
+    x = torch.roll(x, shifts=x.shape[-1] // 2, dims=-1)
+    x[..., : x.shape[-1] // 2] *= -1
+    return x
+
 
 
 def apply_rotary_pos_emb_opt(q, key_states, cos, sin, position_ids):


### PR DESCRIPTION
@fxmarty This change, rewriting `rotate_half` without a `cat` operation, gives a ~1% speedup in compiled code (and pretty much no benefits in uncompiled code)

### Before
2023-06-22 - Llama 7B - main (on `6db8ed51ddebb96f30bd4985241f523468c6f7ce`)
Uncompiled -- `python scripts/run_llama.py --model huggingface/llama-7b --preallocate`
1,no,1000,200,1200,fp16,41.658,14281.74,0d6aa042
Compiled -- `python scripts/run_llama.py --model huggingface/llama-7b --preallocate --compile static`
1,static,1000,200,1200,fp16,45.990,14256.72,0d6aa042

### After
2023-06-22 - Llama 7B - applying these changes on the commit above
Uncompiled -- `python scripts/run_llama.py --model huggingface/llama-7b --preallocate`
1,no,1000,200,1200,fp16,41.789,14281.74,0d6aa042
Compiled -- `python scripts/run_llama.py --model huggingface/llama-7b --preallocate --compile static`
1,static,1000,200,1200,fp16,46.521,14256.72,0d6aa042