### PR TITLE
Quickly plot sweeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Initially taken from Github's Python gitignore file
 
-# TB logs
+# Data created by runs (not to be tracked)
 tb_logs/
+results/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ You can profile a short run with `--profile`, with the TB logs being stored in `
 python run_llama.py --model huggingface/llama-7b --preallocate --profile
 ```
 
-gives, with `batch_size=1`, `prompt_length=1000`, `new_tokens=200`, `cache_length=1200`, `dtype=fp16`:
+## Results
+
+Running the command above with `batch_size=1`, `prompt_length=1000`, `new_tokens=200`, `cache_length=1200`, `dtype=fp16`:
 
 | changes                                                     | compile | tok_per_s | max_mem_mb | hash     | commit                                   |
 |-------------------------------------------------------------|---------|-----------|------------|----------|------------------------------------------|
@@ -55,4 +57,20 @@ can be edited to run a sweep, for example:
 BATCH_SIZES = [1, 2, 4, 8]
 PROMPT_LENGTHS = [500, 1000, 4000]
 NEW_TOKENS = [1000]
+```
+
+## Predefined sweeps
+
+You can sweep over predefined configurations of batch sizes (for a fixed prompt length) and prompt lengths (for a
+fixed batch size) with the `--sweep` flag, e.g.
+
+```
+python scripts/run_llama.py --model huggingface/llama-7b --sweep batch
+```
+
+If you run the sweep for the multiple generation alternatives (original code, with preallocated tensors, and
+preallocated + compiled), you can easily compare the results with
+
+```
+python scripts/plot_results.py --sweep batch
 ```

--- a/scripts/plot_results.py
+++ b/scripts/plot_results.py
@@ -1,0 +1,79 @@
+"""
+Plots the results of a sweep for the current git hash.
+"""
+import argparse
+
+import git
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+
+
+DEFAULT_BATCH_SIZE = 1
+DEFAULT_PROMPT_LENGTH = 1000
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--sweep",
+    type=str,
+    choices=["batch", "length"],
+    required=True,
+    help="Select which type of sweep to plot"
+)
+args = parser.parse_args()
+
+# 1. Read file and retrieve relevant data
+results_file = "./results/results_llama.csv"
+df = pd.read_csv(results_file)
+
+repo = git.Repo(search_parent_directories=True)
+current_git_hash = repo.git.rev_parse(repo.head, short=True)
+df = df[df["Git hash"] == current_git_hash]
+if df.empty:
+    raise ValueError(f"No results found for current git hash ({current_git_hash})")
+
+if args.sweep == "batch":
+    df = df[df["Prompt length"] == DEFAULT_PROMPT_LENGTH]
+else:
+    df = df[df["Batch size"] == DEFAULT_BATCH_SIZE]
+    df = df[df["Prompt length"] != DEFAULT_PROMPT_LENGTH]
+
+if df.empty:
+    raise ValueError("Something went wrong -- no results in the filtered dataframe")
+
+# 2. Plot -- we expect 3 series: original model, preallocated, and preallocated + compiled
+if args.sweep == "batch":
+    x_col_name = "Batch size"
+else:
+    x_col_name = "Prompt length"
+
+df["Type"] = df["Preallocate"].astype("str") + df["Compile"]
+df["Type"] = df["Type"].replace({"Falseno": "original", "Trueno": "Preallocate", "Truestatic": "Pre + comp."})
+
+g = sns.catplot(
+    data=df,
+    kind="bar",
+    x=x_col_name,
+    y="Tokens per second",
+    hue="Type",
+    palette={"original": "blue", "Preallocate": "orange", "Pre + comp.": "red"},
+    alpha=.9,
+)
+g.despine(left=True)
+g.set_axis_labels("Batch size" if args.sweep == "batch" else "Prompt length", "Tokens per second")
+g.legend.set_title("LLaMA code version")
+plt.setp(g._legend.get_texts(), fontsize='7')  # for legend text
+
+title_constant = f'{"Batch size = " + str(DEFAULT_BATCH_SIZE) if args.sweep == "length" else "Prompt length = " + str(DEFAULT_PROMPT_LENGTH)}'
+g.set(title=f'LLaMA sweep ({title_constant})')
+
+# Add the number to the top of each bar
+ax = g.facet_axis(0, 0)
+for i in ax.containers:
+    ax.bar_label(i, fontsize=7)
+
+g.tight_layout()
+plt_path = f"./results/llama_sweep_{current_git_hash}_{args.sweep}.png"
+plt.savefig(plt_path, dpi=300)
+print(f"Plot stored at {plt_path}")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import find_packages, setup
 
-REQUIRED_PKGS = ["torch", "transformers"]
+REQUIRED_PKGS = ["torch", "transformers", "gitpython", "seaborn"]
 
 QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.0.0", "pyyaml>=5.3.1"]
 


### PR DESCRIPTION
@fxmarty this PR adds tools to quickly run and plot sweeps, so we can make deeper comparisons between commits in an automated way.

In particular, we can now trigger a sweep with `--sweep batch` or `--sweep length`, to which triggers a sweep over batch size or prompt length, respectively, storing the result in a dataframe. The results can quickly be plotted with e.g. `python scripts/plot_results.py --sweep length`, which stores a plot to `./results/`

NOTE: I've triggered `max-autotune` during a sweep, so we can see how fast it can go in its compiled form 🚤 

## Results

Here are the plots for the current `main`, on a RTX 3090

### Batch size sweep
![llama_sweep_9b80a35_batch](https://github.com/fxmarty/accelerated-pytorch-transformers-generation/assets/12240844/c2a62224-bc82-4ad8-87f9-a2dc12c2c9c8)

### Prompt length sweep
![llama_sweep_9b80a35_length](https://github.com/fxmarty/accelerated-pytorch-transformers-generation/assets/12240844/5fcebb17-f172-409b-9469-e7c95eab4f4b)
