### PR TITLE
Don't represent valid_past_index as Tensor

### DIFF
--- a/scripts/run_llama.py
+++ b/scripts/run_llama.py
@@ -200,7 +200,7 @@ else:
 if args.compile != "no":
     dynamic = args.compile == "dynamic"
     fullgraph = args.compile == "fullgraph"
-    model.forward = torch.compile(model.forward, mode="reduce-overhead", fullgraph=fullgraph, dynamic=dynamic)
+    model.forward = torch.compile(model.forward, fullgraph=fullgraph, dynamic=dynamic)
 
 if model.config.model_type != "llama":
     raise ValueError("This script currently only supports LLAMA")

--- a/src/trfs_fast/generation.py
+++ b/src/trfs_fast/generation.py
@@ -116,7 +116,7 @@ class GenerationPrefill:
         batch_size, context_length = input_ids.shape
         cache_length = cache_length if cache_length is not None else max_new_tokens
 
-        model_kwargs["valid_past_index"] = torch.tensor(0, dtype=torch.int64)
+        model_kwargs["valid_past_index"] = 0
         model_kwargs["past_key_values"] = self.get_empty_kv_cache(batch_size=batch_size, cache_length=cache_length, device=input_ids.device, dtype=self.dtype)
         model_kwargs["attention_mask"] = self.get_preallocated_attention_mask(attention_mask=model_kwargs["attention_mask"], batch_size=batch_size, cache_length=cache_length, device=input_ids.device, context_length=context_length)
 


### PR DESCRIPTION
To successfully run, you need these upstream PyTorch changes: https://github.com/pytorch/pytorch/pull/104777 (Python only, so you can patch it into a sufficiently recent nightly without rebuilding PyTorch)

Logs from sample run: https://gist.github.com/ezyang/0b46139deca50cbd7e3c320c9193d87b

This turns OFF cudagraphs, as valid_past_index varies from iteration to iteration and cudagraphs cannot deal with it.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
